### PR TITLE
Modification in expiration_seconds to 15 minutes

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/magic/representation/MagicLinkRequest.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/representation/MagicLinkRequest.java
@@ -20,7 +20,7 @@ public class MagicLinkRequest {
   private String redirectUri;
 
   @JsonProperty("expiration_seconds")
-  private int expirationSeconds = 60 * 60 * 24;
+  private int expirationSeconds = 60 * 15;
 
   @JsonProperty("force_create")
   private boolean forceCreate = false;


### PR DESCRIPTION
Description: Updating the default Magic link expiration duration to 15 Minutes .

FIle changed: 1

Path:
src/main/java/io/phasetwo/keycloak/magic/representation/MagicLinkRequest.java 