### PR TITLE
fix: UC-123 update subject text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>io.phasetwo.keycloak</groupId>
   <artifactId>keycloak-magic-link</artifactId>
   <packaging>jar</packaging>
-  <version>0.29</version>
+  <version>0.29.1</version>
 
   <parent>
     <groupId>com.github.xgp</groupId>

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,11 +1,11 @@
 # email
-magicLinkSubject=Log in to {0}
+magicLinkSubject=Login into the WHO Academy Learning platform
 magicLinkBody=Someone requested a login link to {0}.\n\nClick to log in.\n\n{1}\n\nIf you did not request this link, please ignore this email.
 magicLinkBodyHtml=<p>Someone requested a login link to {0}</p><p><a href="{1}">Click to log in</a>.</p><p>If you did not request this link, please ignore this email.</p>
 otpSubject=Your access code for {0}
 otpBody=Someone requested a one-time-password to login to {0}.\n\nCode: {1}\n\nIf you did not request this code, please ignore this email.
 otpBodyHtml=<p>Someone requested a one-time-password to login to {0}.</p><p><b>Code: {1}</b></p><p>If you did not request this code, please ignore this email.</p>
-magicLinkContinuationSubject=Log in to {0}
+magicLinkContinuationSubject=Login into the WHO Academy Learning platform
 magicLinkContinuationBody=Someone requested a login link to {0}.\n\nClick to log in.\n\n{1}\n\nIf you did not request this link, please ignore this email.
 magicLinkContinuationBodyHtml=<p>Someone requested a login link to {0}</p><p><a href="{1}">Click to log in</a>.</p><p>If you did not request this link, please ignore this email.</p>
 

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,11 +1,11 @@
 # email
-magicLinkSubject=Login into the WHO Academy Learning platform
+magicLinkSubject=Login to the WHO Academy Learning platform
 magicLinkBody=Someone requested a login link to {0}.\n\nClick to log in.\n\n{1}\n\nIf you did not request this link, please ignore this email.
 magicLinkBodyHtml=<p>Someone requested a login link to {0}</p><p><a href="{1}">Click to log in</a>.</p><p>If you did not request this link, please ignore this email.</p>
 otpSubject=Your access code for {0}
 otpBody=Someone requested a one-time-password to login to {0}.\n\nCode: {1}\n\nIf you did not request this code, please ignore this email.
 otpBodyHtml=<p>Someone requested a one-time-password to login to {0}.</p><p><b>Code: {1}</b></p><p>If you did not request this code, please ignore this email.</p>
-magicLinkContinuationSubject=Login into the WHO Academy Learning platform
+magicLinkContinuationSubject=Login to the WHO Academy Learning platform
 magicLinkContinuationBody=Someone requested a login link to {0}.\n\nClick to log in.\n\n{1}\n\nIf you did not request this link, please ignore this email.
 magicLinkContinuationBodyHtml=<p>Someone requested a login link to {0}</p><p><a href="{1}">Click to log in</a>.</p><p>If you did not request this link, please ignore this email.</p>
 


### PR DESCRIPTION
**Description**
This PR contains the subject text update when the magic link email is triggered. 

**JIRA**
- https://whoacademy.atlassian.net/browse/UC-123

**Screenshot**
<img width="546" alt="Screenshot 2025-05-23 at 4 43 20 PM" src="https://github.com/user-attachments/assets/b944cfa4-94f4-4ddb-89d4-e6106204565c" />
