### PR TITLE
feat: port whoa specific customization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.phasetwo.keycloak</groupId>
   <artifactId>keycloak-magic-link</artifactId>
   <packaging>jar</packaging>
-  <version>0.73</version>
+  <version>0.73.who.1</version>
 
   <name>Phase Two Keycloak Magic link</name>
   <description>Magic link implementation.</description>

--- a/src/main/java/io/phasetwo/keycloak/magic/MagicLink.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/MagicLink.java
@@ -216,7 +216,7 @@ public final class MagicLink {
       Boolean isActionTokenPersistent,
       String responseMode) {
     // build the action token
-    int validityInSecs = validity.orElse(60 * 60 * 24); // 1 day
+    int validityInSecs = validity.orElse(60 * 15); // 15 minutes
     int absoluteExpirationInSecs = Time.currentTime() + validityInSecs;
     MagicLinkActionToken token =
         new MagicLinkActionToken(

--- a/src/main/java/io/phasetwo/keycloak/magic/representation/MagicLinkRequest.java
+++ b/src/main/java/io/phasetwo/keycloak/magic/representation/MagicLinkRequest.java
@@ -20,7 +20,7 @@ public class MagicLinkRequest {
   private String redirectUri;
 
   @JsonProperty("expiration_seconds")
-  private int expirationSeconds = 60 * 60 * 24;
+  private int expirationSeconds = 60 * 15; // 15 minutes
 
   @JsonProperty("force_create")
   private boolean forceCreate = false;

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,11 +1,11 @@
 # email
-magicLinkSubject=Log in to {0}
+magicLinkSubject=Login to the WHO Academy Learning platform
 magicLinkBody=Someone requested a login link to {0}.\n\nClick to log in.\n\n{1}\n\nIf you did not request this link, please ignore this email.
 magicLinkBodyHtml=<p>Someone requested a login link to {0}</p><p><a href="{1}">Click to log in</a>.</p><p>If you did not request this link, please ignore this email.</p>
 otpSubject=Your access code for {0}
 otpBody=Someone requested a one-time-password to login to {0}.\n\nCode: {1}\n\nIf you did not request this code, please ignore this email.
 otpBodyHtml=<p>Someone requested a one-time-password to login to {0}.</p><p><b>Code: {1}</b></p><p>If you did not request this code, please ignore this email.</p>
-magicLinkContinuationSubject=Log in to {0}
+magicLinkContinuationSubject=Login to the WHO Academy Learning platform
 magicLinkContinuationBody=Someone requested a login link to {0}.\n\nClick to log in.\n\n{1}\n\nIf you did not request this link, please ignore this email.
 magicLinkContinuationBodyHtml=<p>Someone requested a login link to {0}</p><p><a href="{1}">Click to log in</a>.</p><p>If you did not request this link, please ignore this email.</p>
 


### PR DESCRIPTION
## Description

Branch `v0.73.who.1` is based on upstream `v0.73` from [p2-inc/keycloak-magic-link](https://github.com/p2-inc/keycloak-magic-link/tree/v0.73).

This PR ports the WHO Academy specific customizations that previously existed on [`v0.29.1`](https://github.com/WHOAcademy/keycloak-magic-link/tree/v0.29.1), while keeping the implementation based on the newer upstream `v0.73` codebase compatible with Keycloak `26.6.3`.

## Previous WHO Customization Reference

The previous WHO branch had these customization commits:

- [7ed67c0](https://github.com/WHOAcademy/keycloak-magic-link/commit/7ed67c069ba346601b7654c05118af0388fc7f66) - Added PKCE support.
- [874053e](https://github.com/WHOAcademy/keycloak-magic-link/commit/874053ecbb81c7dbe13e051121b2f77b0a520eb1) - Changed REST API `expiration_seconds` default to 15 minutes.
- [dde5504](https://github.com/WHOAcademy/keycloak-magic-link/commit/dde55041ecfed3119da86e071986691a54c8979a) - Changed fallback magic-link token validity to 15 minutes.
- [c5791d6](https://github.com/WHOAcademy/keycloak-magic-link/commit/c5791d6953e03310d315b2b3432485230f3fed8e) - Updated WHO email subject text.
- [5d587ee](https://github.com/WHOAcademy/keycloak-magic-link/commit/5d587ee510c835cf822fa944f92b0da5670a636a) - Corrected WHO email subject text to `Login to the WHO Academy Learning platform`.
- [b5789ba](https://github.com/WHOAcademy/keycloak-magic-link/commit/b5789ba2ae679e996d959910fa1b552710ec028d) - Bumped package version to `0.29.1`.

## Changes Added In This PR

Implemented in:

- [6741c2b](https://github.com/WHOAcademy/keycloak-magic-link/commit/6741c2b5ad4858804c0abe81bdc951aae6d2fb73) - feat: port whoa specific customization

This PR adds the following WHO-specific changes on top of upstream `v0.73`:

- Changes Maven artifact version to `0.73.who.1`.
- Changes magic-link REST API default `expiration_seconds` from 1 day to 15 minutes.
- Changes fallback magic-link token validity from 1 day to 15 minutes.
- Changes English magic-link email subjects to: `Login to the WHO Academy Learning platform`

## Changes that are Not Re-Applied

- The old WHO PKCE commit was not manually re-applied.

Reason: upstream `v0.73` already includes PKCE support, including `code_challenge` and `code_challenge_method` handling.

Relevant upstream commits:

- [038e40a](https://github.com/p2-inc/keycloak-magic-link/commit/038e40af4ee47132937bb687305c46e31c7fd4e7) - Added `code_challenge` for PKCE.
- [dc7b741](https://github.com/p2-inc/keycloak-magic-link/commit/dc7b741cd2bf66f68729a3aa8cd15d02d837bfbc) - Added `code_challenge_method` support.
- [42fff97](https://github.com/p2-inc/keycloak-magic-link/commit/42fff9749646f4ba57285f7ee365baaab3221846) - Added login-token support, including PKCE-related login-token handling.

The intermediate email subject from [c5791d6](https://github.com/WHOAcademy/keycloak-magic-link/commit/c5791d6953e03310d315b2b3432485230f3fed8e) was not preserved because it was superseded by [5d587ee](https://github.com/WHOAcademy/keycloak-magic-link/commit/5d587ee510c835cf822fa944f92b0da5670a636a), which corrected the subject to `Login to the WHO Academy Learning platform`.

The old `0.29.1` version bump was not preserved because this branch is based on upstream `v0.73`. The WHO-specific artifact version is now `0.73.who.1`.

## Verification

Built successfully with:

```
mvn -DskipTests -Dspotless.check.skip=true clean package
```

Generated artifact:
`target/keycloak-magic-link-0.73.who.1.jar`